### PR TITLE
case: fix manifest finding logic

### DIFF
--- a/boaconstructor/__init__.py
+++ b/boaconstructor/__init__.py
@@ -177,7 +177,7 @@ class SmartContractTestCase(unittest.IsolatedAsyncioTestCase):
             raise ValueError("invalid contract path specified")
         _nef = nef.NEF.from_file(str(nef_path.absolute()))
 
-        manifest_path = nef_path.with_suffix("").with_suffix(".manifest.json")
+        manifest_path = nef_path.with_suffix(".manifest.json")
         if not pathlib.Path(manifest_path).is_file():
             raise ValueError(f"can't find manifest at {manifest_path}")
         _manifest = manifest.ContractManifest.from_file(str(manifest_path))


### PR DESCRIPTION
GhostMarket reported an issue where the manifest could not be found when deploying. The reason for that is that their contract name had multiple dots in the filename `GhostMarket.NFT.py`

The first `with_suffix` would strip `.py`, then second `with_suffix` would not only add `.manifest.json` but think that `.NFT` was a suffix and strip that as well. This kind of name was overlooked. Changed the implementation to resolve this.