### PR TITLE
setup: pin Black version to version used in CI

### DIFF
--- a/.github/workflows/validate-pr-commit.yml
+++ b/.github/workflows/validate-pr-commit.yml
@@ -71,7 +71,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: psf/black@stable
         with:
-          options: '--check --target-version py310'
+          options: '--check --target-version py311'
           version: '23.9.1'
           src: "boaconstructor/ examples/ scripts/"
   type-checking:

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ type: ## perform static type checking using mypy
 	mypy boaconstructor/
 
 black: ## apply black formatting
-	black boaconstructor/ examples/ tests/ scripts/
+	black boaconstructor/ examples/ scripts/
 
 build: ## create wheel
 	python -m build && python scripts/fix-wheels.py dist/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-   "black",
+   "black==23.9.1",
    "build==0.10.0",
    "bump-my-version==0.10.0",
    "mypy",


### PR DESCRIPTION
The CI version was pinned, while the project version was not. This pins the project version and also fixes the CI version to check for py311