### PR TITLE
scripts: gracefully handle GitHub rate limiting error when downloading a node

### DIFF
--- a/scripts/download-node.py
+++ b/scripts/download-node.py
@@ -30,11 +30,14 @@ def main():
         doc = parse(f.read())
         target_tag = doc["tool"]["neogo"]["tag"]
 
-        token = os.getenv('GITHUB_TOKEN')
+        token = os.getenv("GITHUB_TOKEN")
         if token is None:
             r = requests.get("https://api.github.com/repos/nspcc-dev/neo-go/releases")
         else:
-            r = requests.get("https://api.github.com/repos/nspcc-dev/neo-go/releases", headers={"authorization": f"Bearer {token}"})
+            r = requests.get(
+                "https://api.github.com/repos/nspcc-dev/neo-go/releases",
+                headers={"authorization": f"Bearer {token}"},
+            )
 
         if r.status_code == 403:
             raise Exception(


### PR DESCRIPTION
When we hit the rate limit on GitHub APIs the `.json()` call 
https://github.com/CityOfZion/boa-test-constructor/blob/311f148f2373b9eafecb3e1a10654ce110cd14b0/scripts/download-node.py#L32-L35

on the response acts really weird and will return a `str` instead of a dictionary causing the following error
```python
 File "/Users/runner/work/boa-test-constructor/boa-test-constructor/boatest/scripts/download-node.py", line 72, in <module>
    main()
  File "/Users/runner/work/boa-test-constructor/boa-test-constructor/boatest/scripts/download-node.py", line 35, in main
    if release["tag_name"] != target_tag:
       ~~~~~~~^^^^^^^^^^^^
TypeError: string indices must be integers, not 'str'
```

It's unclear how we can hit the 60 requests per hour rate limit if we make 6 requests per PR (and it failed on the first PR done in a while). We can improve the setup by including a GitHub token to raise the limit to 1000 per hour. This is for later. 