### PR TITLE
ci: include intel OSX

### DIFF
--- a/.github/workflows/release-to-pypi.yml
+++ b/.github/workflows/release-to-pypi.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-20.04, windows-latest, macos-latest ]
+        os: [ ubuntu-20.04, windows-latest, macos-latest, macos-13 ]
         python-version: ["3.11"]
     steps:
       - name: restore artifact

--- a/.github/workflows/validate-pr-commit.yml
+++ b/.github/workflows/validate-pr-commit.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-20.04, windows-latest, macos-latest ]
+        os: [ ubuntu-20.04, windows-latest, macos-latest, macos-13 ]
         python-version: ["3.11", "3.12"]
     steps:
       - name: Checkout code
@@ -103,7 +103,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-20.04, windows-latest, macos-latest ]
+        os: [ ubuntu-20.04, windows-latest, macos-latest, macos-13 ]
         python-version: ["3.11", "3.12"]
     steps:
       - name: restore artifact

--- a/scripts/fix-wheels.py
+++ b/scripts/fix-wheels.py
@@ -10,6 +10,7 @@ the wheel hence this script.
 import sys
 import pathlib
 import sysconfig
+import platform
 from wheel.cli.tags import tags
 
 
@@ -18,6 +19,11 @@ def main(wheel_dir):
     # PyPi rejects non-manylinux wheels. Change the tag according to PEP-513
     if platform_tag.startswith("linux"):
         platform_tag = platform_tag.replace("linux", "manylinux1")
+    if platform_tag.startswith("macosx"):
+        if platform.machine().lower() == "x86_64":
+            platform_tag = platform_tag.replace("universal2", "x86_64")
+        else:
+            platform_tag = platform_tag.replace("universal2", "arm64")
     for f in pathlib.Path(wheel_dir).glob("**/*"):
         if f.name.endswith("any.whl"):
             tags(str(f.absolute()), None, None, platform_tag, None, True)


### PR DESCRIPTION
and fix universal OSX wheel to be arch specific.

We cannot use `sysconfig.get_platform()` on OSX because the fat binary of Python will return `universal2` as part of its platform tag instead of `arm64` or `x86_64`. This resulted in the release creating a universal OSX wheel packaged with the `arm` version of `neogo` instead of the intel version of `neogo`. 