### PR TITLE
script: fix OSX ARM wheel build

### DIFF
--- a/scripts/fix-wheels.py
+++ b/scripts/fix-wheels.py
@@ -22,8 +22,6 @@ def main(wheel_dir):
     if platform_tag.startswith("macosx"):
         if platform.machine().lower() == "x86_64":
             platform_tag = platform_tag.replace("universal2", "x86_64")
-        else:
-            platform_tag = platform_tag.replace("universal2", "arm64")
     for f in pathlib.Path(wheel_dir).glob("**/*"):
         if f.name.endswith("any.whl"):
             tags(str(f.absolute()), None, None, platform_tag, None, True)


### PR DESCRIPTION
#13 fixed OSX for intel, but consequently broke it for ARM. Where my intel macbook outputs
```shell
$ python3 -m pip debug --verbose | grep py3-none-macosx_10_9_
py3-none-macosx_10_9_x86_64
  py3-none-macosx_10_9_intel
  py3-none-macosx_10_9_fat64
  py3-none-macosx_10_9_fat32
  py3-none-macosx_10_9_universal2
  py3-none-macosx_10_9_universal
```
For Lucas his ARM macbook outputs only
```shell
py3-none-macosx_10_9_universal2
```

As I don't have an ARM based OSX device to test with I have to assume that is the standard. So for OSX ARM we should not replace the tag.