### PR TITLE
node, setup: drop `Node` generalization and pin mypy version

### DIFF
--- a/boaconstructor/__init__.py
+++ b/boaconstructor/__init__.py
@@ -17,7 +17,7 @@ from neo3.api.helpers.signing import (
 from neo3.api.helpers import unwrap
 from neo3.contracts import nef, manifest
 from dataclasses import dataclass
-from boaconstructor.node import NeoGoNode, Node
+from boaconstructor.node import NeoGoNode
 from boaconstructor.storage import PostProcessor
 
 __version__ = "0.3.2"
@@ -40,7 +40,7 @@ T = TypeVar("T")
 
 
 class SmartContractTestCase(unittest.IsolatedAsyncioTestCase):
-    node: Node
+    node: NeoGoNode
     contract_hash: types.UInt160
 
     async def asyncSetUp(self) -> None:

--- a/boaconstructor/node.py
+++ b/boaconstructor/node.py
@@ -7,7 +7,6 @@ import sys
 import time
 import yaml
 import platform
-import abc
 from neo3.wallet import wallet, account
 from neo3.api.wrappers import ChainFacade
 from typing import Optional
@@ -16,28 +15,11 @@ log = logging.getLogger("neogo")
 log.addHandler(logging.StreamHandler(sys.stdout))
 
 
-class Node(abc.ABC):
+class NeoGoNode:
     wallet: wallet.Wallet
     account_committee: account.Account
     facade: ChainFacade
 
-    @classmethod
-    @abc.abstractmethod
-    def start(cls):
-        raise NotImplementedError
-
-    @classmethod
-    @abc.abstractmethod
-    def stop(cls):
-        raise NotImplementedError
-
-    @classmethod
-    @abc.abstractmethod
-    def reset(cls):
-        raise NotImplementedError
-
-
-class NeoGoNode(Node):
     def __init__(self, config_path: Optional[str] = None):
         self.data_dir = pathlib.Path(__file__).parent.joinpath("data")
         if config_path is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dev = [
    "black==23.9.1",
    "build==0.10.0",
    "bump-my-version==0.10.0",
-   "mypy",
+   "mypy==1.16.0",
    "requests",
    "tomlkit==0.12.1",
    "types-PyYAML",


### PR DESCRIPTION
As there is no longer the intention to support `neo-express` in this package we can drop the `Node` "interface" and fix the typing. This also pins `mypy` to a specific version.