### PR TITLE
case: fix `return_type` type annotation of `call` method

### DIFF
--- a/boaconstructor/__init__.py
+++ b/boaconstructor/__init__.py
@@ -4,7 +4,7 @@ import asyncio
 import signal
 import re
 import inspect
-from typing import Optional, TypeVar, Type, Sequence
+from typing import Optional, TypeVar, Type, Sequence, overload
 from neo3.core import types, cryptography
 from neo3.wallet import account
 from neo3.api.wrappers import GenericContract, NEP17Contract, ChainFacade
@@ -73,6 +73,20 @@ class SmartContractTestCase(unittest.IsolatedAsyncioTestCase):
         signal.signal(signal.SIGINT, cleanup)
         cls.node.start()
 
+    @overload
+    @classmethod
+    async def call(
+        cls,
+        method: str,
+        args: Optional[list] = None,
+        *,
+        return_type: None,
+        signing_accounts: Optional[Sequence[account.Account]] = None,
+        signers: Optional[Sequence[Signer]] = None,
+        target_contract: Optional[types.UInt160] = None,
+    ) -> tuple[None, list[noderpc.Notification]]: ...
+
+    @overload
     @classmethod
     async def call(
         cls,
@@ -80,6 +94,18 @@ class SmartContractTestCase(unittest.IsolatedAsyncioTestCase):
         args: Optional[list] = None,
         *,
         return_type: Type[T],
+        signing_accounts: Optional[Sequence[account.Account]] = None,
+        signers: Optional[Sequence[Signer]] = None,
+        target_contract: Optional[types.UInt160] = None,
+    ) -> tuple[T, list[noderpc.Notification]]: ...
+
+    @classmethod
+    async def call(
+        cls,
+        method: str,
+        args: Optional[list] = None,
+        *,
+        return_type,
         signing_accounts: Optional[Sequence[account.Account]] = None,
         signers: Optional[Sequence[Signer]] = None,
         target_contract: Optional[types.UInt160] = None,


### PR DESCRIPTION
The original type `type[T]` was not necessarily wrong, but how we used it was wrong. `Type[T]` means "a class who's instance is of type T". But `None` is an instance (this is where it was wrong). So the correct usage if we'd keep the existing code would be `return_type=type(None)` which looks horrible.

The suggested `type[T] | None` in #20 also wasn't correct and would have different issues. 
1. without changing the return type of the function to `tuple[Optional[T], list[noderpc.Notification]]` the type system would be inconsistent and it is up to the type checker used how it will infer what is returned. It could infer it as described in `2.`
2. if we do change the function return type to `tuple[Optional[T], list[noderpc.Notification]]` to match the function argument, then we're forced to handle a possible `None` even when we supplied something like `return_type=int` and know it will always be an `int`. 

So the only right way (afaik) is to create the type level rule as in this PR which basically says
if `return_type=None` -> function returns `None`
if `return_type=type[T]` -> function returns instance of `T`
